### PR TITLE
Fixes issue with no Authentication attribute in controllers

### DIFF
--- a/nanoFramework.WebServer/WebServer.cs
+++ b/nanoFramework.WebServer/WebServer.cs
@@ -555,7 +555,7 @@ namespace nanoFramework.WebServer
 
                         // Check auth first
                         mustAuthenticate = route.Authentication != null && route.Authentication.AuthenticationType != AuthenticationType.None;
-                        isAuthOk = false;
+                        isAuthOk = !mustAuthenticate;
 
                         if (mustAuthenticate)
                         {
@@ -578,7 +578,7 @@ namespace nanoFramework.WebServer
                             }
                         }
 
-                        if (mustAuthenticate && isAuthOk)
+                        if (isAuthOk)
                         {
                             route.Callback.Invoke(null, new object[] { new WebServerEventArgs(context) });
                         }


### PR DESCRIPTION
## Description
In case we add a controller to our web server that has no authentication attribute ( AuthenticationType.None ) there is an 401 Unauthorized response to the requests. In my opinion it is not right,  and it works differently in the main branch.

It looks like it is an issue introduced during some refactoring changes in the WebServer class.

## How Has This Been Tested?<!-- (if applicable) -->
I've tested it on my esp-wroom-32 device.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
