### PR TITLE
Fix REST API sample URL as it appears samples are consolidated to the nanoFramework repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ There is a more advance example with simple REST API to get a list of Person and
 
 ## A simple GPIO controller REST API
 
-You will find in simple [GPIO controller sample](./WebServer.GpioRest) REST API. The controller not case sensitive and is working like this:
+You will find in simple [GPIO controller sample](https://github.com/nanoframework/Samples/tree/main/samples/Webserver/WebServer.GpioRest) REST API. The controller not case sensitive and is working like this:
 
 - To open the pin 2 as output: http://yoururl/open/2/output
 - To open pin 4 as input: http://yoururl/open/4/input


### PR DESCRIPTION
Fix REST API sample URL as it appears samples are consolidated to the nanoFramework repo.

<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Simple README.MD update to fix URL reference

## Motivation and Context
Broken URL reference

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)
