### PR TITLE
Integration for WebsocketServer

### DIFF
--- a/nanoFramework.WebServer/WebServer.cs
+++ b/nanoFramework.WebServer/WebServer.cs
@@ -593,7 +593,8 @@ namespace nanoFramework.WebServer
                             context.Response.ContentLength64 = 0;
                         }
 
-                        if (context.Response == null) //When context is handed over to WebsocketServer, this will become null
+                        // When context has been handed over to WebsocketServer, it will be null at this point
+                        if (context.Response == null)
                         {
                             //do nothing this is a websocket that is managed by a websocketserver that is responsible for the context now. 
                         }

--- a/nanoFramework.WebServer/WebServer.cs
+++ b/nanoFramework.WebServer/WebServer.cs
@@ -593,8 +593,15 @@ namespace nanoFramework.WebServer
                             context.Response.ContentLength64 = 0;
                         }
 
-                        context.Response.Close();
-                        context.Close();
+                        if (context.Response == null) //When context is handed over to WebsocketServer, this will become null
+                        {
+                            //do nothing this is a websocket that is managed by a websocketserver that is responsible for the context now. 
+                        }
+                        else
+                        {
+                            context.Response.Close();
+                            context.Close();
+                        }
                     }
 
                     if (!isRoute)

--- a/nanoFramework.WebServer/WebServer.cs
+++ b/nanoFramework.WebServer/WebServer.cs
@@ -618,7 +618,7 @@ namespace nanoFramework.WebServer
                         }
 
                         context.Response.Close();
-                        context.Close();
+                        context.Close();                       
                     }
                 }).Start();
 


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
Weserver checks if the WebsocketServer.Response == null before trying to close. When the HttpListnerContext is handed over to a WebsocketServer, Webserver should not try to close the socket anymore. 
<!--- Bulleted list. Full sentences. Ending with a dot. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a null reference error on the HttpListnerContext that happens when a WebserverController would hand over the HttpListnerContext to the WebsocketServer. WebSocketServer sets the inner HttpListnerContext Ouputstream and Inputstream to null.  


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
With numerous browser calls and websocket testing. 

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
