### PR TITLE
Optimizing MCP Server Compatibility for VS 2026 and VS Code

### DIFF
--- a/nanoFramework.WebServer.Mcp/McpPromptRegistry.cs
+++ b/nanoFramework.WebServer.Mcp/McpPromptRegistry.cs
@@ -122,7 +122,7 @@ namespace nanoFramework.WebServer.Mcp
                 }
 
                 sb.Remove(sb.Length - 1, 1);
-                sb.Append("],\"nextCursor\":null");
+                sb.Append("]");
                 return sb.ToString();
             }
             catch (Exception)

--- a/nanoFramework.WebServer.Mcp/McpServerController.cs
+++ b/nanoFramework.WebServer.Mcp/McpServerController.cs
@@ -161,24 +161,34 @@ namespace nanoFramework.WebServer.Mcp
             }
         }
 
-        class ReadOnlyCollection : IEnumerable
+        private class ReadOnlyCollection : IEnumerable
         {
             public ReadOnlyCollection(params object[] values)
             {
                 this.values = new object[values.Length];
                 Array.Copy(values, this.values, values.Length);
             }
+
             private readonly object[] values;
+
             public IEnumerator GetEnumerator() => values.GetEnumerator();
         }
 
         private static bool CheckProtocolVersion(string clientVersion)
         {
             if (SupportedVersion == clientVersion)
+            {
                 return true;
+            }
+
             foreach (string version in OldSupportedVersions)
+            {
                 if (version == clientVersion)
+                {
                     return true;
+                }
+            }
+
             return false;
         }
     }

--- a/nanoFramework.WebServer.Mcp/McpServerController.cs
+++ b/nanoFramework.WebServer.Mcp/McpServerController.cs
@@ -18,7 +18,12 @@ namespace nanoFramework.WebServer.Mcp
         /// <summary>
         /// The supported version of the MCP protocol.
         /// </summary>
-        public const string SupportedVersion = "2025-03-26";
+        public const string SupportedVersion = "2025-11-25";
+
+        /// <summary>
+        /// Gets a collection of old supported versions of the MCP protocol.
+        /// </summary>
+        public static IEnumerable OldSupportedVersions { get; } = new ReadOnlyCollection("2025-03-26", "2025-06-18");
 
         /// <summary>
         /// Gets or sets the server name.
@@ -79,22 +84,26 @@ namespace nanoFramework.WebServer.Mcp
 
                     if (request["method"].ToString() == "initialize")
                     {
+                        string clientVersion = SupportedVersion;
                         // Check if client sent params with protocolVersion
                         if (request.ContainsKey("params") && request["params"] is Hashtable initParams)
                         {
                             if (initParams.ContainsKey("protocolVersion"))
                             {
-                                string clientVersion = initParams["protocolVersion"].ToString();
-                                if (clientVersion != SupportedVersion)
+                                clientVersion = initParams["protocolVersion"].ToString();
+                                if (!CheckProtocolVersion(clientVersion))
                                 {
-                                    sb.Append($",\"error\":{{\"code\":-32602,\"message\":\"Unsupported protocol version\",\"data\":{{\"supported\":[\"{SupportedVersion}\"],\"requested\":\"{clientVersion}\"}}}}}}");
+                                    sb.Append($",\"error\":{{\"code\":-32602,\"message\":\"Unsupported protocol version\",\"data\":{{\"supported\":[");
+                                    foreach (string version in OldSupportedVersions)
+                                        sb.Append($"\"{version}\",");
+                                    sb.Append($"\"{SupportedVersion}\"],\"requested\":\"{clientVersion}\"}}}}}}");
                                     WebServer.OutputAsStream(e.Context.Response, sb.ToString());
                                     return;
                                 }
                             }
                         }
 
-                        sb.Append($",\"result\":{{\"protocolVersion\":\"{SupportedVersion}\"");
+                        sb.Append($",\"result\":{{\"protocolVersion\":\"{clientVersion}\"");
 
                         // Add capabilities
                         sb.Append($",\"capabilities\":{{\"logging\":{{}},\"prompts\":{{\"listChanged\":false}},\"resources\":{{\"subscribe\":false,\"listChanged\":false}},\"tools\":{{\"listChanged\":false}}}}");
@@ -150,6 +159,27 @@ namespace nanoFramework.WebServer.Mcp
             {
                 WebServer.OutputAsStream(e.Context.Response, $"{{\"jsonrpc\":\"2.0\",\"id\":{id},\"error\":{{\"code\":-32602,\"message\":\"{ex.Message}\"}}}}");
             }
+        }
+
+        class ReadOnlyCollection : IEnumerable
+        {
+            public ReadOnlyCollection(params object[] values)
+            {
+                this.values = new object[values.Length];
+                Array.Copy(values, this.values, values.Length);
+            }
+            private readonly object[] values;
+            public IEnumerator GetEnumerator() => values.GetEnumerator();
+        }
+
+        private static bool CheckProtocolVersion(string clientVersion)
+        {
+            if (SupportedVersion == clientVersion)
+                return true;
+            foreach (string version in OldSupportedVersions)
+                if (version == clientVersion)
+                    return true;
+            return false;
         }
     }
 }

--- a/nanoFramework.WebServer.Mcp/McpToolRegistry.cs
+++ b/nanoFramework.WebServer.Mcp/McpToolRegistry.cs
@@ -67,7 +67,9 @@ namespace nanoFramework.WebServer.Mcp
                                     Name = attribute.Name,
                                     Description = attribute.Description,
                                     InputType = inputType,
-                                    OutputType = McpToolJsonHelper.GenerateOutputJson(method.ReturnType, attribute.OutputDescription),
+                                    OutputType = !McpToolJsonHelper.IsPrimitiveType(method.ReturnType) && method.ReturnType != typeof(string)
+                                        ? McpToolJsonHelper.GenerateOutputJson(method.ReturnType, attribute.OutputDescription)
+                                        : string.Empty,
                                     Method = method,
                                     MethodType = parameters.Length > 0 ? parameters[0].ParameterType : null,
                                 });
@@ -104,7 +106,7 @@ namespace nanoFramework.WebServer.Mcp
                 }
 
                 sb.Remove(sb.Length - 1, 1);
-                sb.Append("],\"nextCursor\":null");
+                sb.Append("]");
                 return sb.ToString();
             }
             catch (Exception)

--- a/tests/McpServerTests/McpPromptRegistryTests.cs
+++ b/tests/McpServerTests/McpPromptRegistryTests.cs
@@ -110,7 +110,7 @@ namespace McpServerTests
 
             // Check overall structure
             Assert.IsTrue(metadataJson.StartsWith("\"prompts\":["), "Metadata should start with prompts array");
-            Assert.IsTrue(metadataJson.EndsWith("],\"nextCursor\":null"), "Metadata should end with nextCursor");
+            Assert.IsTrue(metadataJson.EndsWith("]"), "Metadata should end with ']'");
 
             // Check for prompts properties
             Assert.IsTrue(metadataJson.Contains("\"name\":"), "Metadata should contain prompts names");

--- a/tests/McpServerTests/McpToolRegistryTests.cs
+++ b/tests/McpServerTests/McpToolRegistryTests.cs
@@ -92,7 +92,6 @@ namespace McpServerTests
             // Assert
             Assert.IsNotNull(metadataJson, "Metadata JSON should not be null");
             Assert.IsTrue(metadataJson.Contains("\"tools\":["), "Metadata should contain tools array");
-            Assert.IsTrue(metadataJson.Contains("\"nextCursor\":null"), "Metadata should contain nextCursor");
             Assert.IsTrue(metadataJson.Contains("simple_tool"), "Metadata should contain simple_tool");
             Assert.IsTrue(metadataJson.Contains("complex_tool"), "Metadata should contain complex_tool");
             Assert.IsTrue(metadataJson.Contains("nested_tool"), "Metadata should contain nested_tool");
@@ -115,7 +114,6 @@ namespace McpServerTests
             // Assert
             Assert.IsNotNull(metadataJson, "Metadata JSON should not be null");
             Assert.IsTrue(metadataJson.Contains("\"tools\":["), "Metadata should contain tools array");
-            Assert.IsTrue(metadataJson.Contains("\"nextCursor\":null"), "Metadata should contain nextCursor");
             // Should have empty tools array or just the tools from previous test
         }
 
@@ -150,7 +148,7 @@ namespace McpServerTests
 
             // Check overall structure
             Assert.IsTrue(metadataJson.StartsWith("\"tools\":["), "Metadata should start with tools array");
-            Assert.IsTrue(metadataJson.EndsWith("],\"nextCursor\":null"), "Metadata should end with nextCursor");
+            Assert.IsTrue(metadataJson.EndsWith("]"), "Metadata should end with ']'");
 
             // Check for tool properties
             Assert.IsTrue(metadataJson.Contains("\"name\":"), "Metadata should contain tool names");


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
1. Added support for multiple protocol versions
GitHub Copilot Chat in Visual Studio 2026 requires version 2025-06-18, while Visual Studio Code requires version 2025-11-25. Accordingly, the MCP server has been updated to support the latest version (2025-11-25) as well as legacy versions (2025-06-18 and 2025-03-26).

2. Omit outputschema for simple outputs
The outputschema should be omitted from the MCP Tool metadata when the output is not complex. In the latest MCP C# SDK, if an outputschema exists and the type is not an 'object', an exception is thrown. A similar issue was also observed in GitHub Copilot Chat for Visual Studio 2026.

3. Omit "nextCursor": null
In Visual Studio Code, failing to omit nextCursor when it is not needed causes an infinite loop of requests for tools/list and prompts/list methods. Since nextCursor is always fixed to null in the last implementation, it has been removed from the source code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
These updates were implemented after discovering that the .NET nanoFramework MCP server was not functioning correctly with GitHub Copilot Chat in Visual Studio 2026.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified successful operation in GitHub Copilot Chat for both Visual Studio 2026 and Visual Studio Code. Compatibility has also been confirmed with clients based on the latest MCP C# SDK.
## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
