### PR TITLE
Fix typo in McpPromptRegistry and improve JSON safety

### DIFF
--- a/nanoFramework.WebServer.Mcp/McpPromptRegistry.cs
+++ b/nanoFramework.WebServer.Mcp/McpPromptRegistry.cs
@@ -14,7 +14,7 @@ namespace nanoFramework.WebServer.Mcp
     /// </summary>
     public class McpPromptRegistry : RegistryBase
     {
-        private static readonly Hashtable promtps = new Hashtable();
+        private static readonly Hashtable prompts = new Hashtable();
         private static bool isInitialized = false;
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace nanoFramework.WebServer.Mcp
                                     throw new Exception($"Method {method.Name} does not return an array of PromptMessage.");
                                 }
 
-                                promtps.Add(attribute.Name, new PromptMetadata
+                                prompts.Add(attribute.Name, new PromptMetadata
                                 {
                                     Name = attribute.Name,
                                     Description = attribute.Description,
@@ -115,13 +115,16 @@ namespace nanoFramework.WebServer.Mcp
                 StringBuilder sb = new StringBuilder();
                 sb.Append("\"prompts\":[");
 
-                foreach (PromptMetadata prompt in promtps.Values)
+                foreach (PromptMetadata prompt in prompts.Values)
                 {
                     sb.Append(prompt.ToString());
                     sb.Append(",");
                 }
 
-                sb.Remove(sb.Length - 1, 1);
+                if (prompts.Count > 0)
+                {
+                    sb.Remove(sb.Length - 1, 1);
+                }
                 sb.Append("]");
                 return sb.ToString();
             }
@@ -139,9 +142,9 @@ namespace nanoFramework.WebServer.Mcp
         /// <exception cref="Exception">Thrown when the specified prompt is not found in the registry.</exception>
         public static string GetPromptDescription(string promptName)
         {
-            if (promtps.Contains(promptName))
+            if (prompts.Contains(promptName))
             {
-                PromptMetadata promptMetadata = (PromptMetadata)promtps[promptName];
+                PromptMetadata promptMetadata = (PromptMetadata)prompts[promptName];
                 return promptMetadata.Description;
             }
 
@@ -157,9 +160,9 @@ namespace nanoFramework.WebServer.Mcp
         /// <exception cref="Exception">Thrown when the specified prompt is not found in the registry.</exception>
         public static string InvokePrompt(string promptName, Hashtable arguments)
         {
-            if (promtps.Contains(promptName))
+            if (prompts.Contains(promptName))
             {
-                PromptMetadata promptMetadata = (PromptMetadata)promtps[promptName];
+                PromptMetadata promptMetadata = (PromptMetadata)prompts[promptName];
                 MethodInfo method = promptMetadata.Method;
                 Debug.WriteLine($"Prompt name: {promptName}, method: {method.Name}");
 

--- a/nanoFramework.WebServer.Mcp/McpToolRegistry.cs
+++ b/nanoFramework.WebServer.Mcp/McpToolRegistry.cs
@@ -105,7 +105,10 @@ namespace nanoFramework.WebServer.Mcp
                     sb.Append(",");
                 }
 
-                sb.Remove(sb.Length - 1, 1);
+                if (tools.Count > 0)
+                {
+                    sb.Remove(sb.Length - 1, 1);
+                }
                 sb.Append("]");
                 return sb.ToString();
             }


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
- Fixed a typo from `promtps` to `prompts` in `McpPromptRegistry.cs`.
- Added a `Count > 0` check to prevent exceptions when converting prompts and tools to JSON strings if no items exist. Applied the same safety improvements to `McpToolRegistry.cs`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Found that adding an MCP server fails in Visual Studio when registering MCP tools without prompts, as the absence of prompts causes the '[' character to be omitted from the resulting JSON.
- Note that in Visual Studio Code, the MCP server was still functional; unlike Visual Studio 2026, it proceeds to fetch the tool list even if the prompt list retrieval fails.
## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`nanoFramework.WebServer/tests/McpEndToEndTest/Program.cs`
```csharp
McpToolRegistry.DiscoverTools(new Type[] { typeof(McpServerTests.McpTools) });
Debug.WriteLine("MCP Tools discovered and registered.");

//McpPromptRegistry.DiscoverPrompts(new Type[] { typeof(McpServerTests.McpPrompts) });
//Debug.WriteLine("MCP Prompts discovered and registered.");
```

## Screenshots<!-- (IF APPROPRIATE): -->

- Visual Studio 2026
![vs2026](https://github.com/user-attachments/assets/d2fd043e-b7c4-4d05-8ed6-b4c984fa7fec)
- Visual Studio Code
![vscode](https://github.com/user-attachments/assets/029ff331-9c61-4d2a-9935-da90de0e0747)

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
