### PR TITLE
Harden WebServer listener and ReadBody

### DIFF
--- a/nanoFramework.WebServer/HttpListenerRequestExtensions.cs
+++ b/nanoFramework.WebServer/HttpListenerRequestExtensions.cs
@@ -21,45 +21,82 @@ namespace nanoFramework.WebServer
             MultipartFormDataParser.Parse(httpListenerRequest.InputStream);
 
         /// <summary>
-        /// Reads a body from the HttpListenerRequest inputstream
+        /// Reads a body from the HttpListenerRequest inputstream.
         /// </summary>
         /// <param name="httpListenerRequest">The request to read the body from</param>
-        /// <returns>A byte[] containing the body of the request</returns>
+        /// <returns>
+        /// A byte[] containing the body of the request, or <see langword="null"/> if the body could not be read.
+        /// </returns>
         public static byte[] ReadBody(this HttpListenerRequest httpListenerRequest)
         {
-            byte[] body = new byte[httpListenerRequest.ContentLength64];
-            byte[] buffer = new byte[4096];
-            Stream stream = httpListenerRequest.InputStream;
+            long contentLength = httpListenerRequest.ContentLength64;
 
-            int position = 0;
-
-            while (true)
+            // check missing or invalid content-length
+            if (contentLength <= 0)
             {
-                // The stream is (should be) a NetworkStream which might still be receiving data while
-                // we're already processing. Give the stream a chance to receive more data or we might
-                // end up with "zero bytes read" too soon...
-                Thread.Sleep(1);
-
-                long length = stream.Length;
-
-                if (length > buffer.Length)
-                {
-                    length = buffer.Length;
-                }
-
-                int bytesRead = stream.Read(buffer, 0, (int)length);
-
-                if (bytesRead == 0)
-                {
-                    break;
-                }
-
-                Array.Copy(buffer, 0, body, position, bytesRead);
-
-                position += bytesRead;
+                return new byte[0];
             }
 
-            return body;
+            // Sanity check for huge content-length
+            // A managed array cannot exceed int.MaxValue elements
+            // Treat an oversized Content-Length the same as an allocation failure.
+            if (contentLength > int.MaxValue)
+            {
+                return null;
+            }
+
+            try
+            {
+                int bodySize = (int)contentLength;
+                byte[] body = new byte[bodySize];
+                byte[] buffer = new byte[4096];
+                Stream stream = httpListenerRequest.InputStream;
+
+                int position = 0;
+
+                while (position < bodySize)
+                {
+                    // The stream is (should be) a NetworkStream which might still be receiving data while
+                    // we're already processing. Give the stream a chance to receive more data or we might
+                    // end up with "zero bytes read" too soon...
+                    Thread.Sleep(1);
+
+                    long length = stream.Length;
+
+                    if (length <= 0)
+                    {
+                        break;
+                    }
+
+                    if (length > buffer.Length)
+                    {
+                        length = buffer.Length;
+                    }
+
+                    long remaining = bodySize - position;
+                    if (length > remaining)
+                    {
+                        length = remaining;
+                    }
+
+                    int bytesRead = stream.Read(buffer, 0, (int)length);
+
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+
+                    Array.Copy(buffer, 0, body, position, bytesRead);
+
+                    position += bytesRead;
+                }
+
+                return body;
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }

--- a/nanoFramework.WebServer/WebServer.cs
+++ b/nanoFramework.WebServer/WebServer.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
@@ -664,7 +665,20 @@ namespace nanoFramework.WebServer
                 _listener.Start();
                 while (!_cancel)
                 {
-                    HttpListenerContext context = _listener.GetContext();
+                    HttpListenerContext context;
+
+                    try
+                    {
+                        context = _listener.GetContext();
+                    }
+                    catch (SocketException)
+                    {
+                        // possibly a transient connection error
+                        // (e.g. OS captive-portal probe reset before request line is received)
+                        // this allows continue and accepting the next connection
+                        continue;
+                    }
+
                     if (context == null)
                     {
                         return;
@@ -672,143 +686,159 @@ namespace nanoFramework.WebServer
 
                     new Thread(() =>
                     {
-                        //This is for handling with transitory or bad requests
-                        if (context.Request.RawUrl == null)
+                        try
                         {
-                            return;
-                        }
-
-                        CallbackRoutes selectedRoute = null;
-                        bool selectedRouteHasAuth = false;
-                        string multipleCallback = null;
-                        bool hasAuthRoutes = false;
-                        string basicAuthNoCred = null;
-                        bool authFailed = false;
-
-                        // Variables used only within the "for". They are here for performance reasons
-                        bool mustAuthenticate;
-                        bool isAuthOk;
-
-                        foreach (CallbackRoutes route in _callbackRoutes)
-                        {
-                            if (!IsRouteMatch(route, context.Request.HttpMethod, context.Request.RawUrl))
+                            //This is for handling with transitory or bad requests
+                            if (context.Request.RawUrl == null)
                             {
-                                continue;
+                                return;
                             }
 
-                            // Check auth first
-                            mustAuthenticate = route.Authentication != null && route.Authentication.AuthenticationType != AuthenticationType.None;
-                            if (mustAuthenticate)
+                            CallbackRoutes selectedRoute = null;
+                            bool selectedRouteHasAuth = false;
+                            string multipleCallback = null;
+                            bool hasAuthRoutes = false;
+                            string basicAuthNoCred = null;
+                            bool authFailed = false;
+
+                            // Variables used only within the "for". They are here for performance reasons
+                            bool mustAuthenticate;
+                            bool isAuthOk;
+
+                            foreach (CallbackRoutes route in _callbackRoutes)
                             {
-                                hasAuthRoutes = true;
-                                if (route.Authentication.AuthenticationType == AuthenticationType.Basic)
+                                if (!IsRouteMatch(route, context.Request.HttpMethod, context.Request.RawUrl))
                                 {
-                                    var credReq = context.Request.Credentials;
-                                    if (credReq is null)
-                                    {
-                                        if (basicAuthNoCred is null)
-                                        {
-                                            basicAuthNoCred = route.Route;
-                                        }
-
-                                        continue;
-                                    }
-
-                                    var credSite = route.Authentication.Credentials ?? Credential;
-
-                                    isAuthOk = credSite != null
-                                        && (credSite.UserName == credReq.UserName)
-                                        && (credSite.Password == credReq.Password);
-                                }
-                                else if (route.Authentication.AuthenticationType == AuthenticationType.ApiKey)
-                                {
-                                    var apikeyReq = GetApiKeyFromHeaders(context.Request.Headers);
-                                    if (apikeyReq is null)
-                                    {
-                                        continue;
-                                    }
-
-                                    var apikeySite = route.Authentication.ApiKey ?? ApiKey;
-
-                                    isAuthOk = apikeyReq == apikeySite;
-                                }
-                                else
-                                {
-                                    isAuthOk = false;
-                                }
-
-                                if (isAuthOk)
-                                {
-                                    // This route can be used and has precedence over non-authenticated routes
-                                    if (!selectedRouteHasAuth)
-                                    {
-                                        selectedRoute = null;
-                                        multipleCallback = null;
-                                    }
-
-                                    selectedRouteHasAuth = true;
-                                }
-                                else
-                                {
-                                    authFailed = true;
                                     continue;
                                 }
+
+                                // Check auth first
+                                mustAuthenticate = route.Authentication != null && route.Authentication.AuthenticationType != AuthenticationType.None;
+                                if (mustAuthenticate)
+                                {
+                                    hasAuthRoutes = true;
+                                    if (route.Authentication.AuthenticationType == AuthenticationType.Basic)
+                                    {
+                                        var credReq = context.Request.Credentials;
+                                        if (credReq is null)
+                                        {
+                                            if (basicAuthNoCred is null)
+                                            {
+                                                basicAuthNoCred = route.Route;
+                                            }
+
+                                            continue;
+                                        }
+
+                                        var credSite = route.Authentication.Credentials ?? Credential;
+
+                                        isAuthOk = credSite != null
+                                            && (credSite.UserName == credReq.UserName)
+                                            && (credSite.Password == credReq.Password);
+                                    }
+                                    else if (route.Authentication.AuthenticationType == AuthenticationType.ApiKey)
+                                    {
+                                        var apikeyReq = GetApiKeyFromHeaders(context.Request.Headers);
+                                        if (apikeyReq is null)
+                                        {
+                                            continue;
+                                        }
+
+                                        var apikeySite = route.Authentication.ApiKey ?? ApiKey;
+
+                                        isAuthOk = apikeyReq == apikeySite;
+                                    }
+                                    else
+                                    {
+                                        isAuthOk = false;
+                                    }
+
+                                    if (isAuthOk)
+                                    {
+                                        // This route can be used and has precedence over non-authenticated routes
+                                        if (!selectedRouteHasAuth)
+                                        {
+                                            selectedRoute = null;
+                                            multipleCallback = null;
+                                        }
+
+                                        selectedRouteHasAuth = true;
+                                    }
+                                    else
+                                    {
+                                        authFailed = true;
+                                        continue;
+                                    }
+                                }
+                                else if (selectedRouteHasAuth || authFailed)
+                                {
+                                    // The selected route has authentication and/or a route exists with failed authentication.
+                                    // Those have precedence over non-authenticated routes
+                                    continue;
+                                }
+
+                                if (selectedRoute is null)
+                                {
+                                    selectedRoute = route;
+                                }
+                                else
+                                {
+                                    multipleCallback ??= $"Multiple matching callbacks: {selectedRoute.Callback.DeclaringType.FullName}.{selectedRoute.Callback.Name}";
+                                    multipleCallback += $", {route.Callback.DeclaringType.FullName}.{route.Callback.Name}";
+                                }
                             }
-                            else if (selectedRouteHasAuth || authFailed)
-                            {
-                                // The selected route has authentication and/or a route exists with failed authentication.
-                                // Those have precedence over non-authenticated routes
-                                continue;
-                            }
+
 
                             if (selectedRoute is null)
                             {
-                                selectedRoute = route;
-                            }
-                            else
-                            {
-                                multipleCallback ??= $"Multiple matching callbacks: {selectedRoute.Callback.DeclaringType.FullName}.{selectedRoute.Callback.Name}";
-                                multipleCallback += $", {route.Callback.DeclaringType.FullName}.{route.Callback.Name}";
-                            }
-                        }
-
-
-                        if (selectedRoute is null)
-                        {
-                            if (hasAuthRoutes)
-                            {
-                                if (!authFailed && basicAuthNoCred is not null)
+                                if (hasAuthRoutes)
                                 {
-                                    context.Response.Headers.Add("WWW-Authenticate",
-                                        $"Basic realm=\"Access to {basicAuthNoCred}\"");
-                                }
+                                    if (!authFailed && basicAuthNoCred is not null)
+                                    {
+                                        context.Response.Headers.Add("WWW-Authenticate",
+                                            $"Basic realm=\"Access to {basicAuthNoCred}\"");
+                                    }
 
-                                context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-                                context.Response.ContentLength64 = 0;
+                                    context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                                    context.Response.ContentLength64 = 0;
+                                }
+                                else if (CommandReceived != null)
+                                {
+                                    // Starting a new thread to be able to handle a new request in parallel
+                                    CommandReceived.Invoke(this, new WebServerEventArgs(context));
+                                }
+                                else
+                                {
+                                    context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                                    context.Response.ContentLength64 = 0;
+                                }
                             }
-                            else if (CommandReceived != null)
+                            else if (multipleCallback is not null)
                             {
-                                // Starting a new thread to be able to handle a new request in parallel
-                                CommandReceived.Invoke(this, new WebServerEventArgs(context));
+                                multipleCallback += ".";
+                                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                                OutputAsStream(context.Response, multipleCallback);
                             }
                             else
                             {
-                                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                                InvokeRoute(selectedRoute, context);
+                            }
+
+                            HandleContextResponse(context);
+                        }
+                        catch (Exception ex)
+                        {
+
+                            try
+                            {
+                                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
                                 context.Response.ContentLength64 = 0;
                             }
+                            catch
+                            {
+                                // Response may already be partially sent or the connection closed; nothing to do.
+                            }
                         }
-                        else if (multipleCallback is not null)
-                        {
-                            multipleCallback += ".";
-                            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
-                            OutputAsStream(context.Response, multipleCallback);
-                        }
-                        else
-                        {
-                            InvokeRoute(selectedRoute, context);
-                        }
-
-                        HandleContextResponse(context);
                     }).Start();
 
                 }


### PR DESCRIPTION
## Description
- Add guards against zero/overflow content-lengths and catches all exceptions in ReadBody(). Teturning null instead of propagating to the caller.
- Wrap StartListner code with try catch blocks.
- Each request thread now also catches unhandled exceptions and returns 500.
- Fix IntelliSense comment in ReadBody.

## Motivation and Context
- A SocketException from GetContext() was propagating out of StartListener, killing the accept loop on transient captive-portal probe resets.
- Issues found when debugging a captive portal project.
- Bottom line, these changes were added to harden code and make more robust, so the server doesn't crash.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Local project running smoothly.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
