### PR TITLE
Fix possible this workflow uses `secrets: inherit` to pass all of the calling workfl… in generate-changelog.ym

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -13,4 +13,5 @@ jobs:
   compose_changelog:
     name: nanoFramework
     uses: nanoframework/nf-tools/.github/workflows/generate-changelog.yml@main
-    secrets: inherit
+    secrets:
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}


### PR DESCRIPTION
This changes `.github/workflows/generate-changelog.yml` to address something a scan flagged. It is around line 16.

The workflow uses `secrets: inherit`, which automatically forwards **all** repository secrets to the called reusable workflow. This breaks the principle of least privilege: if the reusable workflow is compromised—or is sourced from an external repository—an attacker could obtain every secret (e.g., tokens, passwords, API keys). The impact is a potential full‑repository secret leak, leading to credential theft, supply‑chain attacks, and unauthorized actions. The risk is classified as **high** (CWE‑250).

Replace insecure `secrets: inherit` with explicit `GIT_TOKEN` secret mapping to follow the principle of least privilege.

For reference: rule `yaml.github-actions.security.secrets-inherit.secrets-inherit`, [CWE-250 (Execution with Unnecessary Privileges)](https://cwe.mitre.org/data/definitions/250.html). Rated high.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
